### PR TITLE
normalize mathy note marks in frontmatter down to plaintext

### DIFF
--- a/bindings/ar5iv.sty.ltxml
+++ b/bindings/ar5iv.sty.ltxml
@@ -14,4 +14,33 @@ use LaTeXML::Package;
 # No \today, useful when re-converting older archival articles
 DefMacroI('\today', undef, '\relax', locked => 1, scope => 'global');
 
+# Experiment: When we detect a math element containing solely a floating superscript in the
+#             *Frontmatter* of a document, assume it is a note mark, and normalize it down to
+#             plain text.
+DefRewrite(xpath => 'descendant::*[local-name()="creator" or local-name()="titlepage"]' .
+    '/descendant::ltx:Math[child::ltx:XMath[child::ltx:XMApp[' .
+    '@role="FLOATSUPERSCRIPT" and not(preceding-sibling::*) and not(following-sibling::*)]]]',
+  replace => sub {
+    my ($document, $math) = @_;
+# We can assume the grandchild of the XMath node is the XMArg, which we need to normalize to scripted Unicode.
+    if (my @xmath = element_nodes($math)) {
+      if (my @xmapp = element_nodes($xmath[0])) {
+        if (my @xmarg = element_nodes($xmapp[0])) {
+          my $text = $xmarg[0]->textContent;
+          # For now be conservative and only recognize
+          # - numeric cases
+          # - daggers
+          # - latin letters
+          # - basic ,; punctuation
+          # - spaces
+          if ($text && $text =~ /^[,;\x{2020}\x{2021}\d\sa-z]+$/) {
+            local $LaTeXML::BOX = $document->getNodeBox($document->getNode->parentNode);
+            $document->insertElement('ltx:sup', $text);
+            return;
+    } } } }
+    # should never happen, but just in case:
+    Warn("rewrite", "footnotemark", "Failed to substitute math script with a ltx:sup text equivalent.");
+    $document->getNode->appendChild($math);
+    return; });
+
 1;

--- a/bindings/biblatex.sty.ltxml
+++ b/bindings/biblatex.sty.ltxml
@@ -21,9 +21,7 @@ DefKeyVal('biblatex', 'maxbibnames', 'Number', '4', code => sub {
 DeclareOption(undef, sub { });    # for now ignore all other ooptions.
 ProcessOptions(inorder => 1, keysets => ['biblatex']);
 
-RequirePackage('url');
-# convenience addon, in case hyperref is not loaded.
-DefMacro('\href Verbatim {}', '\@@Url\href{}{}{#1}{#2}');
+RequirePackage('hyperref'); # for url and href
 #RequirePackage('natbib');
 # RequirePackage('logreq');
 RequirePackage('ifthen');


### PR DESCRIPTION
Idea: try to detect math made up of solely floating superscripts in the frontmatter section of a document, and normalize it down to a textual `ltx:sup` equivalent. This ought to aid both accessibility (no needless mention of "starting math") and search engines (no extra noise in the index).

For now I am suggesting this as a contained experiment for the arXiv conversion (localized to the `ar5iv-bindings` repository here). But I would still ask @brucemiller for a review here, if he is so inclined, as I don't write `DefRewrite` rules too often.